### PR TITLE
Update CircleCI config to use CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
+            - v2-dependencies-{{ checksum "package.json" }}
+            - v2-dependencies-
       - run: yarn install
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v2-dependencies-{{ checksum "package.json" }}
       - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,11 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "package.json" }}
-            - v2-dependencies-
-      - run: yarn install
+          key: dependency-cache
+      - run:
+          name: install
+          command: yarn install --ignore-engines
       - save_cache:
+          key: dependency-cache
           paths:
-            - node_modules
-          key: v2-dependencies-{{ checksum "package.json" }}
-      - run: yarn test
+            - ./node_modules


### PR DESCRIPTION
As of March 15, 2019, CircleCI 1.0 cloud infrastructure is no longer available. This PR updates said service config to use CircleCI 2.0.